### PR TITLE
bump version to clear circleCI cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memjs",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "memjs",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "12.20.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Amit Levy",
   "name": "memjs",
   "description": "A memcache client for node using the binary protocol and SASL authentication",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "MIT",
   "homepage": "http://github.com/memcachier/memjs",
   "keywords": [


### PR DESCRIPTION
CircleCi is failing because npm with hash didn't get cleared on CircleCI.

Bump version to clear circleCI cache